### PR TITLE
test(pre-commit): remove timeout override

### DIFF
--- a/test/pre-commit.spec.js
+++ b/test/pre-commit.spec.js
@@ -30,8 +30,6 @@ describe('pre-commit', function () {
   });
 
   it('should succeed when the hook succeeds', function () {
-    this.timeout(5000); // times out on Travis with the default 2000
-
     var commitMsgExpected = 'testing pre-commit';
     var commitMsgActual = 'did not get set';
 


### PR DESCRIPTION
global values is greater now

This is why the build on master failed (despite passing in PR #19 before the squash)